### PR TITLE
Pretty messages

### DIFF
--- a/ChannelSurfCli/Utils/Channels.cs
+++ b/ChannelSurfCli/Utils/Channels.cs
@@ -36,6 +36,12 @@ namespace ChannelSurfCli.Utils
                             channelId = "";
                         }
 
+                        if ((bool)obj.SelectToken("is_archived"))
+                        {
+                            Console.WriteLine("Skipping archived slack channel: {0}", obj["name"].ToString());
+                            continue;
+                        }
+
                         slackChannels.Add(new Models.Slack.Channels()
                         {
                             channelId = channelId,

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Either way, you'll need to decide if you want to:
 	
 	You can create a Slack Team export on a self-service basis as a Slack Team Owner or Admin at this page [https://my.slack.com/services/export](https://my.slack.com/services/export).  Download the export file and tell Channel Surf its location.   We'll scan it and re-create the Slack channel structure in Teams - and give you the option to do more.  
 	
-	WARNING: Slack channels can be public or private - a concept not currently supported in Microsoft Teams.  This import tool will re-create all Slack channels in MS Teams, irrespective of whether they were public or private in Slack.  Want that to change?  Go ahead and [https://github.com/tamhinsf/ChannelSurf/issues:](file an issue).
+	WARNING: Slack channels can be public or private - a concept not currently supported in Microsoft Teams.  This import tool will re-create all Slack channels in MS Teams, irrespective of whether they were public or private in Slack.  Want that to change?  Go ahead and [file an issue](https://github.com/tamhinsf/ChannelSurf/issues).
 
   * Archive Slack message history (optional)
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ Either way, you'll need to decide if you want to:
 * Re-create Slack channels
 	
 	You can create a Slack Team export on a self-service basis as a Slack Team Owner or Admin at this page [https://my.slack.com/services/export](https://my.slack.com/services/export).  Download the export file and tell Channel Surf its location.   We'll scan it and re-create the Slack channel structure in Teams - and give you the option to do more.  
+	
+	WARNING: Slack channels can be public or private - a concept not currently supported in Microsoft Teams.  This import tool will re-create all Slack channels in MS Teams, irrespective of whether they were public or private in Slack.  Want that to change?  Go ahead and [https://github.com/tamhinsf/ChannelSurf/issues:](file an issue).
 
   * Archive Slack message history (optional)
 


### PR DESCRIPTION
We wanted the exported message history to be a little more user-friendly by formatting the timestamp nicely, and showing user mentions by username instead of user_id.   Implemented DetectSlackParens.  Also skipped importing archived channels.  